### PR TITLE
fix: fixing order fragments to retrieve coupons object

### DIFF
--- a/packages/sdk-api-client/src/api/fragments/orderFragment.ts
+++ b/packages/sdk-api-client/src/api/fragments/orderFragment.ts
@@ -9,7 +9,10 @@ order {
   dateOrder
   orderUrl
   stage
-  coupons
+  coupons {
+    code
+    id
+  }
   websiteOrderLine {
     id
     name


### PR DESCRIPTION
changing query base order fragments